### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/v2/data/popup/index.js
+++ b/v2/data/popup/index.js
@@ -165,7 +165,7 @@ function check() {
 }
 
 chrome.runtime.onMessage.addListener(request => {
-  const twoDigit = num => ('00' + num).substr(-2);
+  const twoDigit = num => ('00' + num).slice(-2);
   if (request.method === 'updated-info') {
     const obj = request.data;
 

--- a/v3/api.js
+++ b/v3/api.js
@@ -79,7 +79,7 @@ api.match = (key = '', str = '', parent = undefined) => {
   // RegExp matching
   if (key.startsWith('re:')) {
     try {
-      const r = new RegExp(key.substr(3));
+      const r = new RegExp(key.slice(3));
 
       return r.test(str);
     }
@@ -91,7 +91,7 @@ api.match = (key = '', str = '', parent = undefined) => {
   // URLPattern matching
   else if (key.startsWith('pt:')) {
     try {
-      let v = key.substr(3);
+      let v = key.slice(3);
       if (v.startsWith('http') === false) {
         v = 'http{s}?://' + v;
       }
@@ -108,7 +108,7 @@ api.match = (key = '', str = '', parent = undefined) => {
   else if (key.startsWith('ht:')) {
     try {
       // https://*.example.com/test*
-      const [hostname, ...parts] = key.substr(3).replace(/^https?:\/\//, '').split('/');
+      const [hostname, ...parts] = key.slice(3).replace(/^https?:\/\//, '').split('/');
       const [pathname, search] = parts.join('/').split('?');
 
       const pattern = new URLPattern({

--- a/v3/data/scripts/interpreter/acorn.js
+++ b/v3/data/scripts/interpreter/acorn.js
@@ -5427,7 +5427,7 @@
       }
     default:
       if (ch >= 48 && ch <= 55) {
-        var octalStr = this.input.substr(this.pos - 1, 3).match(/^[0-7]+/)[0];
+        var octalStr = this.input.slice(this.pos - 1, this.pos + 2).match(/^[0-7]+/)[0];
         var octal = parseInt(octalStr, 8);
         if (octal > 255) {
           octalStr = octalStr.slice(0, -1);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.